### PR TITLE
Add plus(+) icon to experience time in skills

### DIFF
--- a/utils/getExperienceTime.ts
+++ b/utils/getExperienceTime.ts
@@ -7,13 +7,13 @@ const getExperienceTime = (startDate: Date) => {
   months += currDate.getMonth();
 
   if (months < 12) {
-    return `${months} month${months > 1 ? 's' : ''} experience`
+    return `${months}+ month${months > 1 ? 's' : ''} experience`
   }
   else {
     const restMonths = months % 12
     const years = Math.round(months / 12)
 
-    return `${years} year${years > 1 ? 's' : ''} experience`
+    return `${years}+ year${years > 1 ? 's' : ''} experience`
   }
 }
 


### PR DESCRIPTION
The skills experience time doesn't represent the precisely date so I add the plus(+) icon.