### PR TITLE
added key to get rid of warning in console

### DIFF
--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -101,6 +101,7 @@ const Header: React.FC = props => {
         <Divider />
         {navLinks.map(item => (
           <motion.div
+            key={item.label}
             initial="hidden"
             animate="visible"
             transition={transition}


### PR DESCRIPTION
In header component, While looping through navLinks, in motion component it required key to uniquely identify, I was showing warning, so added key to get rid of warning in console. Please request u to merge the pull request if u find useful.